### PR TITLE
fix: drop support for 32 bit architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
     main: ./
     binary: manager
 


### PR DESCRIPTION
This drops support for building 32-bit binaries, as they were failing our release process. We'll need further changes if we need to support 32-bit architectures in the future.