### PR TITLE
feat: add iamRoleArn field to cert-manager

### DIFF
--- a/.codegen/certificates/cert-manager/rbac.yaml
+++ b/.codegen/certificates/cert-manager/rbac.yaml
@@ -20,6 +20,10 @@ automountServiceAccountToken: true
 metadata:
   name: cert-manager
   namespace: nukleros-certs-system # +operator-builder:field:name=namespace,default="nukleros-certs-system",type=string
+  annotations:
+    # +operator-builder:field:name=iamRoleArn,type=string,description=`
+    # On AWS, the IAM Role ARN that gives cert-manager access to Route53`
+    eks.amazonaws.com/role-arn: iam_role_arn
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager

--- a/.codegen/preserved-assets/Makefile
+++ b/.codegen/preserved-assets/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= "nukleros/support-services-operator:latest"
+IMG ?= "ghcr.io/nukleros/support-services-operator:latest"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= "nukleros/support-services-operator:dev"
+IMG ?= "ghcr.io/nukleros/support-services-operator:latest"
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 

--- a/apis/certificates/v1alpha1/certmanager/rbac.go
+++ b/apis/certificates/v1alpha1/certmanager/rbac.go
@@ -79,6 +79,11 @@ func CreateServiceAccountNamespaceCertManager(
 			"metadata": map[string]interface{}{
 				"name":      "cert-manager",
 				"namespace": parent.Spec.Namespace, //  controlled by field: namespace
+				"annotations": map[string]interface{}{
+					// controlled by field: iamRoleArn
+					//  On AWS, the IAM Role ARN that gives cert manager access to Route53
+					"eks.amazonaws.com/role-arn": parent.Spec.IamRoleArn,
+				},
 				"labels": map[string]interface{}{
 					"app":                          "cert-manager",
 					"app.kubernetes.io/name":       "cert-manager",

--- a/apis/certificates/v1alpha1/certmanager/resources.go
+++ b/apis/certificates/v1alpha1/certmanager/resources.go
@@ -49,6 +49,7 @@ spec:
     replicas: 2
     image: "quay.io/jetstack/cert-manager-webhook"
   contactEmail: "admin@nukleros.io"
+  iamRoleArn: "iam_role_arn"
 `
 
 // sampleCertManagerRequired is a sample containing only required fields
@@ -61,6 +62,7 @@ spec:
     #name: "supportservices-sample"
     #namespace: ""
   contactEmail: "admin@nukleros.io"
+  iamRoleArn: "iam_role_arn"
 `
 
 // Sample returns the sample manifest for this custom resource.

--- a/apis/certificates/v1alpha1/certmanager_types.go
+++ b/apis/certificates/v1alpha1/certmanager_types.go
@@ -67,6 +67,10 @@ type CertManagerSpec struct {
 	// +kubebuilder:validation:Required
 	//  Contact e-mail address for receiving updates about certificates from LetsEncrypt.
 	ContactEmail string `json:"contactEmail,omitempty"`
+
+	// +kubebuilder:validation:Required
+	//  On AWS, the IAM Role ARN that gives cert-manager access to Route53
+	IamRoleArn string `json:"iamRoleArn,omitempty"`
 }
 
 type CertManagerCollectionSpec struct {

--- a/config/crd/bases/certificates.support-services.nukleros.io_certmanagers.yaml
+++ b/config/crd/bases/certificates.support-services.nukleros.io_certmanagers.yaml
@@ -84,6 +84,10 @@ spec:
                       controller deployment.'
                     type: integer
                 type: object
+              iamRoleArn:
+                description: On AWS, the IAM Role ARN that gives cert-manager access
+                  to Route53
+                type: string
               namespace:
                 default: nukleros-certs-system
                 description: '(Default: "nukleros-certs-system") Namespace to use

--- a/config/samples/certificates_v1alpha1_certmanager.yaml
+++ b/config/samples/certificates_v1alpha1_certmanager.yaml
@@ -18,3 +18,4 @@ spec:
     replicas: 2
     image: "quay.io/jetstack/cert-manager-webhook"
   contactEmail: "admin@nukleros.io"
+  iamRoleArn: "iam_role_arn"


### PR DESCRIPTION
Add support for an `iamRoleArn` field. This will allow cert-manager to authenticate to AWS when configured with an appropriate role for it to assume.