### PR TITLE
feat: add GCP Cloud DNS support to ExternalDNS controller

### DIFF
--- a/apis/gateway/v1alpha1/externaldns/mutate/secret_namespace_external_dns_google.go
+++ b/apis/gateway/v1alpha1/externaldns/mutate/secret_namespace_external_dns_google.go
@@ -17,6 +17,9 @@ limitations under the License.
 package mutate
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nukleros/operator-builder-tools/pkg/controller/workload"
@@ -36,7 +39,28 @@ func MutateSecretNamespaceExternalDnsGoogle(
 		return []client.Object{original}, nil
 	}
 
-	// mutation logic goes here
+	secret, ok := original.(*unstructured.Unstructured)
+	if !ok {
+		return []client.Object{original}, fmt.Errorf("expected *unstructured.Unstructured, got %T", original)
+	}
 
-	return []client.Object{original}, nil
+	if parent.Spec.GcpProject != "" {
+		if err := unstructured.SetNestedField(secret.Object, parent.Spec.GcpProject, "stringData", "EXTERNAL_DNS_GOOGLE_PROJECT"); err != nil {
+			return []client.Object{original}, fmt.Errorf("failed to set GCP project: %w", err)
+		}
+	}
+
+	if parent.Spec.DomainName != "" {
+		if err := unstructured.SetNestedField(secret.Object, parent.Spec.DomainName, "stringData", "EXTERNAL_DNS_DOMAIN_FILTER"); err != nil {
+			return []client.Object{original}, fmt.Errorf("failed to set domain filter: %w", err)
+		}
+	}
+
+	if parent.Spec.ZoneType != "" {
+		if err := unstructured.SetNestedField(secret.Object, parent.Spec.ZoneType, "stringData", "EXTERNAL_DNS_GOOGLE_ZONE_VISIBILITY"); err != nil {
+			return []client.Object{original}, fmt.Errorf("failed to set zone visibility: %w", err)
+		}
+	}
+
+	return []client.Object{secret}, nil
 }

--- a/apis/gateway/v1alpha1/externaldns/mutate/service_account_namespace_service_account_name.go
+++ b/apis/gateway/v1alpha1/externaldns/mutate/service_account_namespace_service_account_name.go
@@ -17,6 +17,9 @@ limitations under the License.
 package mutate
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nukleros/operator-builder-tools/pkg/controller/workload"
@@ -36,7 +39,19 @@ func MutateServiceAccountNamespaceServiceAccountName(
 		return []client.Object{original}, nil
 	}
 
-	// mutation logic goes here
+	if parent.Spec.Provider != "google" || parent.Spec.GcpProject == "" {
+		return []client.Object{original}, nil
+	}
 
-	return []client.Object{original}, nil
+	sa, ok := original.(*unstructured.Unstructured)
+	if !ok {
+		return []client.Object{original}, fmt.Errorf("expected *unstructured.Unstructured, got %T", original)
+	}
+
+	gcpSaEmail := fmt.Sprintf("external-dns@%s.iam.gserviceaccount.com", parent.Spec.GcpProject)
+	if err := unstructured.SetNestedField(sa.Object, gcpSaEmail, "metadata", "annotations", "iam.gke.io/gcp-service-account"); err != nil {
+		return []client.Object{original}, fmt.Errorf("failed to set Workload Identity annotation: %w", err)
+	}
+
+	return []client.Object{sa}, nil
 }

--- a/apis/gateway/v1alpha1/externaldns_types.go
+++ b/apis/gateway/v1alpha1/externaldns_types.go
@@ -23,8 +23,6 @@ import (
 	"github.com/nukleros/operator-builder-tools/pkg/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	certificatesv1alpha1 "github.com/nukleros/support-services-operator/apis/certificates/v1alpha1"
 )
 
 var ErrUnableToConvertExternalDNS = errors.New("unable to convert to ExternalDNS")
@@ -60,6 +58,10 @@ type ExternalDNSSpec struct {
 
 	// +kubebuilder:validation:Required
 	DomainName string `json:"domainName,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	//  GCP project ID used when provider is "google".
+	GcpProject string `json:"gcpProject,omitempty"`
 
 	// +kubebuilder:default="k8s.gcr.io/external-dns/external-dns"
 	// +kubebuilder:validation:Optional
@@ -203,9 +205,7 @@ func (component *ExternalDNS) SetChildResourceCondition(resource *status.ChildRe
 
 // GetDependencies returns the dependencies for a component.
 func (*ExternalDNS) GetDependencies() []workload.Workload {
-	return []workload.Workload{
-		&certificatesv1alpha1.CertManager{},
-	}
+	return []workload.Workload{}
 }
 
 // GetComponentGVK returns a GVK object for the component.

--- a/config/crd/bases/gateway.support-services.nukleros.io_externaldns.yaml
+++ b/config/crd/bases/gateway.support-services.nukleros.io_externaldns.yaml
@@ -56,6 +56,9 @@ spec:
                 type: object
               domainName:
                 type: string
+              gcpProject:
+                description: GCP project ID used when provider is "google".
+                type: string
               extraArgs:
                 description: Extra arguments to be passed into the External DNS container.
                 items:


### PR DESCRIPTION
Add gcpProject field to ExternalDNSSpec and implement the previously no-op mutate functions so the ExternalDNS controller can fully manage external-dns for GCP without manual intervention.

- ExternalDNSSpec: add GcpProject field; remove CertManager from GetDependencies() so ExternalDNS can be reconciled without cert-manager installed
- MutateSecretNamespaceExternalDnsGoogle: inject GcpProject, DomainName and ZoneType from spec into the external-dns-google Secret, replacing the hardcoded "my-project"/"mydomain.com" placeholders
- MutateServiceAccountNamespaceServiceAccountName: add the iam.gke.io/gcp-service-account annotation to the external-dns ServiceAccount when provider is "google", enabling GKE Workload Identity without manual annotation
- CRD YAML: add gcpProject field to the OpenAPI schema